### PR TITLE
fix: make the job service account roles namespace wide

### DIFF
--- a/templates/aws-ecr.job.yaml
+++ b/templates/aws-ecr.job.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     spec:
       terminationGracePeriodSeconds: 600
-      serviceAccountName: {{ .Release.Name }}-service-account
+      serviceAccountName: k8s-registry-auth-service-account
       restartPolicy: OnFailure
       containers:
         - name: kubectl
@@ -66,7 +66,7 @@ spec:
       template:
         spec:
           terminationGracePeriodSeconds: 600
-          serviceAccountName: {{ .Release.Name }}-service-account
+          serviceAccountName: k8s-registry-auth-service-account
           restartPolicy: OnFailure
           containers:
             - name: kubectl

--- a/templates/docker.job.yaml
+++ b/templates/docker.job.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     spec:
       terminationGracePeriodSeconds: 600
-      serviceAccountName: {{ .Release.Name }}-service-account
+      serviceAccountName: k8s-registry-auth-service-account
       restartPolicy: Never
       containers:
         - name: kubectl

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -1,18 +1,29 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-service-account
+  name: k8s-registry-auth-service-account
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: Role
 metadata:
-  name: {{ .Release.Name }}-service-account
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
+  namespace: {{ .Release.Namespace }}
+  name: k8s-registry-auth-secret-manager
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: k8s-registry-auth-secret-manager-binding
+  namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-service-account
+    name: k8s-registry-auth-service-account
     namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: k8s-registry-auth-secret-manager
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
# Current Behaviour
- The permission that the job get to delete and re-create the auth secret was cluster wide
# Expected Behaviour
- The permission that job gets to delete/re-create the secret is per namespace and filtered