### PR TITLE
feat: global image registry

### DIFF
--- a/templates/aws-ecr.job.yaml
+++ b/templates/aws-ecr.job.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: kubectl
-          image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ default .Values.image.registry .Values.global.imageRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
           command:
             - "/bin/sh"
             - "-c"

--- a/templates/docker.job.yaml
+++ b/templates/docker.job.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: kubectl
-          image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ default .Values.image.registry .Values.global.imageRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
           command:
             - "/bin/sh"
             - "-c"

--- a/values.yaml
+++ b/values.yaml
@@ -1,3 +1,5 @@
+global:
+  imageRegistry: ""
 # this is the repository that we try to authenticate upon
 # Can be any aws ecr related repository or other docker based repositories
 # ex. 123456789123.dkr.ecr.eu-west-2.amazonaws.com


### PR DESCRIPTION
# Current Behaviour
- the image used to create the authentication secret get only static registry from yaml
# Expected Behaviour
- enabling the `global.imageRegistry` override of container image registry